### PR TITLE
Update pom to point to dependencies for model and exception classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,20 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
+        <dependency>
+            <groupId>com.lactaoen.blackjack.model</groupId>
+            <artifactId>blackjack-models</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../Blackjack/target/blackjack-1.0-SNAPSHOT.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>com.lactaoen.blackjack.exception</groupId>
+            <artifactId>blackjack-models</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/../Blackjack/target/blackjack-1.0-SNAPSHOT.jar</systemPath>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
This will change will point to the server jar file that this client is dependent on. Only requirement is that both modules are in the same parent directory.

E.g., 
~/challenge/Blackjack
~/challenge/BlackjackClient
